### PR TITLE
Fix: Product solution

### DIFF
--- a/exercise-solutions/Product.hs
+++ b/exercise-solutions/Product.hs
@@ -1,2 +1,2 @@
 product' :: (Num a) => [a] -> a
-product' = foldr1 (*)
+product' = foldr (*) 1


### PR DESCRIPTION
Why
---

Product solution raises for an empty list, unlike `Prelude.product`

What
----

Use `Prelude.foldr` instead of `Prelude.foldr1` in _Product.hs_