### PR TITLE
Fix: Elem solution

### DIFF
--- a/exercise-solutions/ElemFold.hs
+++ b/exercise-solutions/ElemFold.hs
@@ -1,4 +1,4 @@
 module ElemFold (elem') where
 
 elem' :: (Eq a) => a -> [a] -> Bool
-elem' y ys = foldl (\acc x -> if x == y then True else acc) False ys
+elem' y = foldr (\x acc -> x == y || acc) False


### PR DESCRIPTION
Why
---

Product solution does not short circuit, unlike `Prelude.elem`

E.g., `elem 42 $ repeat 42` evaluates `True`

What
----

* Use `Prelude.foldr` instead of `Prelude.foldl` to take advantage of short-circuiting
* Use `Prelude.||` instead of `if-then-else` syntax
* Eta reduce